### PR TITLE
fix: use correct token for flake lock updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: "Test Local Action"
         uses: "./"
         with:
-          github-access-token: "${{ secrets.MANAGED_MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}"
+          github-access-token: "${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}"
 
       - name: "Test: nix --version"
         run: |

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -22,4 +22,6 @@ jobs:
 
       - name: "Update flake.lock"
         uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
+        with:
+          token: ${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}
 


### PR DESCRIPTION
## Summary
- Use `MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE` in the `update-flake-lock` workflow so the bot has write access to push branches and create PRs (fixes [this run](https://github.com/flox/configure-nix-action/actions/runs/24041167774/job/70113012132))
- Fix typo in `ci.yml` where `MANAGED_MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE` had a double `MANAGED_` prefix

## Test plan
- [x] Manually trigger the "Update flake.lock" workflow and verify it can push and create a PR
- [x] Verify CI passes on the test-minimal-action job with the corrected secret name

🤖 Generated with [Claude Code](https://claude.com/claude-code)