### PR TITLE
chore: migrate the action runtime from `node20` to `node24`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,18 +26,16 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
 
       - name: "Install Nix"
-        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
 
 
       - name: "Cache Dependencies"
         id: cache
-        uses: "actions/cache@8070854e57d983bdd2887b0a708ad985f77398ab"
-        env:
-          GITHUB_ACTIONS_RUNNER_FORCED_NODE_VERSION: node20
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           key: npm-${{ matrix.os }}-${{ hashFiles('package-lock.json') }}
           path: ./node_modules
@@ -69,11 +67,11 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
 
       - name: "Install Nix"
-        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
 
 
       - name: "Test Local Action"
@@ -97,11 +95,11 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
 
       - name: "Setup Tailscale"
-        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
 
         with:
           oauth-secret: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
@@ -110,7 +108,7 @@ jobs:
           use-cache: true
 
       - name: "Install Nix"
-        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
 
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -150,11 +148,11 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
 
       - name: "Setup Tailscale"
-        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
 
         with:
           oauth-secret: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
@@ -163,7 +161,7 @@ jobs:
           use-cache: true
 
       - name: "Install Nix"
-        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
 
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -204,7 +202,7 @@ jobs:
 
     steps:
       - name: "Slack Notification"
-        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2
 
         env:
           SLACK_TITLE:      "Something broke CI for flox/configure-nix-action on main"

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -30,11 +30,11 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
 
       - name: "Install Nix"
-        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
 
 
       - name: "Install Dependencies"
@@ -48,7 +48,7 @@ jobs:
         run: git status
 
       - name: "Commit changes"
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
 
         with:
           file_pattern: "dist/index.js badges/coverage.svg"

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -11,13 +11,13 @@ jobs:
     steps:
 
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
         with:
           fetch-depth: 0
 
       - name: "Install Nix"
-        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
 
 
       - name: "Update flake.lock"

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Install Nix
-      uses: cachix/install-nix-action
+      uses: cachix/install-nix-action@v31
 
     - name: Configure Nix
-      uses: flox/configure-nix-action
+      uses: flox/configure-nix-action@main
       with: ...options...
 
     - name: Build

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,6 @@ inputs:
     description: "AWS secret key to upload"
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
   post: 'dist/index.js'

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "lastModified": 1785692966,
+        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
          devShells.default = pkgs.mkShell {
            name = "configure-nix-action";
            packages = with pkgs; [
-             nodejs_20
+             nodejs_24
            ];
          };
        }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     ".": "./dist/index.js"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "scripts": {
     "postinstall": "patch-package",


### PR DESCRIPTION
## Summary

GitHub deprecated the Node 20 runtime for JavaScript actions: runners have defaulted to Node 24 since June 16, 2026, and Node 20 will be removed from the runner entirely in fall 2026 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Because `action.yml` declared `using: 'node20'`, every workflow consuming this action emitted a deprecation warning. The action now declares `node24`, the Nix dev shell provides `nodejs_24`, and `engines` in `package.json` requires Node 24 or newer.

The node20 pin was also blocking routine maintenance. Current nixpkgs has removed `nodejs_20` outright, which is why the weekly `flake.lock` update (#39) has failed CI since April; with the dev shell on `nodejs_24`, this PR carries the lock forward from May 2025 to current nixos-unstable. Dependabot's action-pin bumps (#43) failed CI only because Dependabot-triggered runs cannot read the repo's Tailscale secret, so this PR adopts those bumps directly. It additionally bumps `actions/cache`, which was pinned to an untagged 2023 commit that Dependabot could not map to a version; the pin now carries a version comment (`v6.1.0`) so Dependabot can manage it in the future. The `GITHUB_ACTIONS_RUNNER_FORCED_NODE_VERSION` env var on the cache step, originally a workaround forcing a newer runtime than the runner default, had inverted into a pin on the deprecated one and is removed. The README example is refreshed to current action versions.

Consumers on self-hosted runners need runner v2.327.1 or later for Node 24.

Supersedes #39 and #43.

### Test plan

- [x] `nix develop --command node --version` reports v24.18.1 from the updated lock
- [x] `npm ci` and `npm run all` in the dev shell: jest passes under Node 24, and the ncc rebuild produced a byte-identical `dist/index.js`
- [x] CI green on this PR, including the Tailscale-backed integration jobs
- [x] Workflow annotations show no node20 deprecation warnings