### PR TITLE
fix: add SSH keepalives so stalled builder connections fail fast

### DIFF
--- a/scripts/configure-ssh.sh
+++ b/scripts/configure-ssh.sh
@@ -26,6 +26,18 @@ fi
 
 echo "Configure ssh to allow builtins.fetchGit and related to work"
 
+# Detect and drop stalled SSH connections to remote builders instead of
+# hanging until the job timeout. Builder connections are opened by the
+# nix daemon (root), so this must be system-wide client config, not
+# $HOME/.ssh/config. Both Linux and macOS ship an
+# "Include /etc/ssh/ssh_config.d/*" in /etc/ssh/ssh_config.
+sudo mkdir -p /etc/ssh/ssh_config.d
+printf "%s\n" \
+  'Host *' \
+  '  ServerAliveInterval 15' \
+  '  ServerAliveCountMax 4' |
+  sudo tee /etc/ssh/ssh_config.d/10-keepalive.conf >/dev/null
+
 
 mkdir -p "$HOME/.ssh"
 ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"


### PR DESCRIPTION
## Summary

Remote builds over `ssh-ng` currently have no keepalive: when a
connection to a remote builder stalls mid-transfer, nix waits forever
and the GitHub job burns its full 2-hour timeout. We hit this on
2026-08-24 with `hetzner-x86-64-indigo-04` (Tailscale SSH sessions
dropped mid-copy, leaving `nix-daemon --stdio` orphans server-side
and hung `copying path ... to 'ssh-ng://...'` client-side — see the
cancelled main-branch CI runs in flox/floxhub, e.g. run 32781511277).

This installs a system-wide ssh client drop-in
(`/etc/ssh/ssh_config.d/10-keepalive.conf`):

```
Host *
  ServerAliveInterval 15
  ServerAliveCountMax 4
```

A dead connection is now detected after ~60s, so nix errors out (and
can pick another builder) instead of wedging the whole CI run.

Notes:

- System-wide (not `~/.ssh/config`) because builder connections are
  opened by the nix daemon as root.
- Both Linux and macOS runners include `/etc/ssh/ssh_config.d/*`
  from the stock `/etc/ssh/ssh_config`.

## Testing

- Pending: run a flox/floxhub CI build against this branch and confirm
  builder connections still work on both ubuntu and macos runners.